### PR TITLE
Switch from subprocess to pexpect for remote ssh interaction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+colored
+pexpect

--- a/stackyter.py
+++ b/stackyter.py
@@ -66,9 +66,8 @@ def get_config(config, configfile):
     return config
 
 
-if __name__ == '__main__':
-
-    description = """Run Jupyter on a distant host and display it localy."""
+def setup_parser():
+    description = "Run Jupyter on a distant host and display it localy."
     prog = "stackyter.py"
     usage = """%s [options]""" % prog
 
@@ -111,6 +110,11 @@ if __name__ == '__main__':
     parser.add_argument('-S', '--showconfig', action='store_true', default=False,
                         help='Show all available configurations from your default file and exit.')
 
+    return parser
+
+
+def main():
+    parser = setup_parser()
     args = parser.parse_args()
     default_args = parser.parse_args(args=[])
 


### PR DESCRIPTION
This PR demonstrates the use of `pexpect` for remote ssh interaction
without shell display. It cleans up the terminal output.

Try it up:
```bash
pip install -r requirements.txt
python stackyter.py
```

Pros:
- fine control of what is passed to the remote
- possibility of restarting easily the connexion if lost (TODO)

Downside:
- adds two requirements `pexpect` (mandatory) and `colored` (optional)
for the colored display of the url
- so far I could not manage to create the ssh tunnel with these tools
(might need to use `subprocess` for that actually :| )

This is more of a personal exercise but if you find it useful we could
work this way.