### PR TITLE
adding SafeLoader to yaml loader

### DIFF
--- a/stackyter.py
+++ b/stackyter.py
@@ -29,13 +29,13 @@ def get_default_config(only_path=False):
         config = DEFAULT_CONFIG
     else:
         return None
-    return yaml.load(open(config, 'r')) if not only_path else config
+    return yaml.load(open(config, 'r'), Loader=yaml.SafeLoader) if not only_path else config
 
 
 def read_config(config, key=None):
     """Read a config file and return the right configuration."""
     print("INFO: Loading configuration from", config)
-    config = yaml.load(open(config, 'r'))
+    config = yaml.load(open(config, 'r'), Loader=yaml.SafeLoader)
     if key is not None:
         if key in config:
             print("INFO: Using the '%s' configuration" % key)


### PR DESCRIPTION
This is to prevent the following warning and future deprecation.
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

SafeLoader is enough for the currently defined config files.