### PR TITLE
Create pypi.yml

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,18 @@
+name: pypi_publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build package
+      run: python setup.py sdist
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Allow automated publication of pypi package.

Hi
I have noticed that the latest version of stackyter (0.3) had not been published on pypi.
This PR would ensure automated publication of stackyter on pypi after the creation of a GitHub release in the future.
To do so, it only requires an admin to connect to pypi and create a new token for stackyter:
https://pypi.org/manage/account/token/
and copy this token in github repo settings as a new secret named `PYPI_API_TOKEN`:
https://github.com/nicolaschotard/stackyter/settings/secrets/actions/new