### PR TITLE
Add ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Your documentation on ReadTheDocs on the latest tag is failing for 2 months because the package needs to be installed first.

This PR adds a configuration file which is the recommended way to configure your project.

It should find it in the root of the repository and use it by default, so you should already see that this PR is able to re-build the documentation (if you activated the builds for PRs in your ReadTheDocs project, otherwise you need to merge first).